### PR TITLE
Cache result of gmod.GetGamemode() in hook.Run

### DIFF
--- a/lua/ulib/shared/hook.lua
+++ b/lua/ulib/shared/hook.lua
@@ -82,8 +82,14 @@ end
 --
 -- Run a hook (this replaces Call)
 --
+local currentGM
+
 function Run( name, ... )
-	return Call( name, gmod and gmod.GetGamemode() or nil, ... )
+	if ( !currentGM ) then
+		currentGM = gmod and gmod.GetGamemode() or nil
+	end
+
+	return Call( name, currentGM, ... )
 end
 
 --


### PR DESCRIPTION
Simply merges the standard hook library changes with yours. Optimizes hook.Run